### PR TITLE
✨  feat : 질문 대상 조회, 삭제 API 구조 구현 및 Axios 기본 구조 변경

### DIFF
--- a/src/api/ApiAxios.js
+++ b/src/api/ApiAxios.js
@@ -1,7 +1,14 @@
 import axios from 'axios';
 
+const BASE_URL = 'https://openmind-api.vercel.app';
+const TEAM = '18-1';
+
 const instance = axios.create({
-  baseURL: 'https://openmind-api.vercel.app/18-1',
+  baseURL: `${BASE_URL}/${TEAM}`,
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
 });
 
 export default instance;

--- a/src/api/deleteSubjectsId.js
+++ b/src/api/deleteSubjectsId.js
@@ -1,0 +1,10 @@
+import instance from './ApiAxios.js';
+
+export const deleteSubjectsId = async subjectsId => {
+  try {
+    await instance.delete(`/subjects/${subjectsId}/`);
+    return true;
+  } catch (e) {
+    throw new Error(`질문 대상 삭제 실패 : ${e.message}`);
+  }
+};

--- a/src/api/getSubjectsId.js
+++ b/src/api/getSubjectsId.js
@@ -1,0 +1,11 @@
+import instance from './ApiAxios.js';
+
+// 특정 질문 대상 조회
+export const getSubjectsId = async subjectsId => {
+  try {
+    const response = await instance.get(`/subjects/${subjectsId}/`);
+    return response.data;
+  } catch (e) {
+    throw new Error(`질문 대상 조회 실패 : ${e.message}`);
+  }
+};


### PR DESCRIPTION
## 📌 PR 제목

- 질문 대상 조회, 삭제 API 구조 구현 및 Axios 기본 구조 변경

## 📝 작업 내용

- axios가 선언된 구조 파일을 좀 더 용이하게 변경해보았습니다.
- 원선님이 분리해주신 api 폴더에 getSubjectsId.js , deleteSubjectsId.js 총 두 개의 파일을 만들었습니다.
- getSubjectsId.js는 헷갈리지만 개별 피드의 정보를 받아오는 것 같습니다..
- deleteSubjectsId.js는 본인 개별 피드에 들어갔을시 삭제하기 버튼에 적용하는 것 같습니다.

## 🔍 주요 변경 사항

일단 기존 FETCH 형식의 코드들은 냅뒀고 새로 두 개의 API 요청만 axios로 만들어봤습니다.
저도 잘 모르는 부분이라 같이 알아가면 좋을 것 같습니다.

## 💬 기타 참고 사항

혹시라도 이미 API 연결을 진행하고 계시다면 말씀해주세요! PR 지우겠습니다.
