### PR TITLE
답변하기 api 연동

### DIFF
--- a/src/api/answers.js
+++ b/src/api/answers.js
@@ -1,0 +1,35 @@
+// src/api/answers.js
+import instance from './ApiAxios';
+
+// 1) 답변 생성 (POST /questions/{questionId}/answers/)
+export const createAnswer = (questionId, { content, isRejected = false }) => {
+  // ⚠️ isRejected는 boolean으로 보내야 함 ("false" X)
+  return instance
+    .post(`/questions/${questionId}/answers/`, {
+      content,
+      isRejected,
+    })
+    .then(res => res.data);
+};
+
+// 2) 답변 조회 (GET /answers/{answerId}/)
+export const getAnswer = answerId => {
+  return instance.get(`/answers/${answerId}/`).then(res => res.data);
+};
+
+// 3) 답변 삭제 (DELETE /answers/{answerId}/)
+export const deleteAnswer = answerId => {
+  return instance.delete(`/answers/${answerId}/`).then(() => true);
+};
+
+// 4) 답변 수정
+// PUT: 전체 교체(content, isRejected 모두 필요)
+export const putAnswer = (answerId, { content, isRejected }) => {
+  return instance
+    .put(`/answers/${answerId}/`, { content, isRejected })
+    .then(res => res.data);
+};
+// PATCH: 일부만 수정
+export const patchAnswer = (answerId, partial) => {
+  return instance.patch(`/answers/${answerId}/`, partial).then(res => res.data);
+};

--- a/src/components/Answer/AnswerCard.jsx
+++ b/src/components/Answer/AnswerCard.jsx
@@ -13,10 +13,10 @@ export default function AnswerCard({
   authorImage,
   question,
   createdAt,
-  answer, // { id, content } | null
-  onCreate, // (questionId, content) => Promise<answer>
-  onEdit, // (answerId, content) => Promise<answer>
-  onDelete, // (answerId) => Promise<void>
+  answer,
+  onCreate,
+  onEdit,
+  onDelete,
 }) {
   const [mode, setMode] = useState('idle'); // idle, editing, confirm-delete
   const [vote, setVote] = useState(null); // like, dislike, null

--- a/src/pages/Answer.jsx
+++ b/src/pages/Answer.jsx
@@ -2,13 +2,13 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-// API
+// 백엔드 API
 import { getQuestion } from '../api/getQuestion';
 import { getSubjectsId } from '../api/getSubjectsId';
 import { deleteSubjectsId } from '../api/deleteSubjectsId';
 import { createAnswer, deleteAnswer, patchAnswer } from '../api/answers';
 
-// 팀 공용 헤더(배경 + 프로필)
+// 팀 공용 헤더, 자꾸 깨져서 불러와서 사용
 import Headers from '../components/question/Headers';
 
 // SVG
@@ -39,7 +39,7 @@ export default function Answer() {
   const [loading, setLoading] = useState(true);
   const [loadErr, setLoadErr] = useState('');
 
-  // 훅은 항상 호출되도록 유지, 내부 가드로 빠른 종료
+  // 유즈이펙트 항시불러오기 유지 (경고창 오류 지우기)
   useEffect(() => {
     if (!subjectId) {
       setLoading(false);
@@ -75,7 +75,7 @@ export default function Answer() {
             questionId: q.id,
             question: q.content ?? '(내용 없음)',
             createdAt: q.createdAt ? timeAgo(q.createdAt) : '방금 전',
-            author: q.authorName ?? q.author?.name ?? '익명', // 질문 작성자(표시는 안 쓰지만 데이터는 유지)
+            author: q.authorName ?? q.author?.name ?? '익명', // 질문 작성자가 추가되면 해당이름 표시하게끔
             answer: firstAnswer,
           };
         });
@@ -87,7 +87,7 @@ export default function Answer() {
         }
       } finally {
         if (!cancelled) {
-          setLoading(false); // finally 안 return 금지 → 가드로 처리
+          setLoading(false);
         }
       }
     })();
@@ -97,6 +97,7 @@ export default function Answer() {
     };
   }, [subjectId]);
 
+  //답변하기 최상단 삭제하기 버튼, 메인페이지에서 생성한 아이디 삭제
   const handleDeleteProfile = async () => {
     if (!subjectId) return;
     const ok = window.confirm('프로필을 삭제하시겠습니까?');
@@ -139,7 +140,7 @@ export default function Answer() {
             }
           />
 
-          {/* 프로필 삭제 버튼 */}
+          {/* 프로필 삭제 버튼 ui */}
           <div className="w-full flex justify-center">
             <div className="w-[716px] flex justify-end mt-[172px]">
               <button
@@ -180,7 +181,7 @@ export default function Answer() {
                   <AnswerCard
                     key={c.questionId}
                     questionId={c.questionId}
-                    // ✅ 답변자 영역을 메인 프로필로 일치
+                    // 답변자 이름, 사진을 메인에서 생성한 프로필로 동기화
                     author={userInfo?.name ?? '내 프로필'}
                     authorImage={userInfo?.imageSource ?? null}
                     question={c.question}
@@ -205,7 +206,7 @@ export default function Answer() {
 function AnswerCard({
   questionId,
   author,
-  authorImage, // ✅ 추가: 메인 프로필 이미지
+  authorImage, //메인 프로필 이미지
   question,
   createdAt,
   initialAnswer,
@@ -217,7 +218,7 @@ function AnswerCard({
   const [editText, setEditText] = useState('');
 
   const [menuOpen, setMenuOpen] = useState(false);
-  const [mode, setMode] = useState('idle'); // 'idle' | 'editing' | 'confirm-delete'
+  const [mode, setMode] = useState('idle'); // 'idle' | 'editing' | confirm-delete 확인할것
   const [vote, setVote] = useState(null);
   const menuRef = useRef(null);
 
@@ -228,7 +229,7 @@ function AnswerCard({
 
   const isAnswered = !!answer;
 
-  // 바깥 클릭 닫기
+  // 외부 클릭하면 창 닫기
   useEffect(() => {
     const onClickOutside = e => {
       if (!menuRef.current) return;
@@ -253,7 +254,7 @@ function AnswerCard({
       setAnswer(created);
       setText('');
     } catch (e) {
-      setError(apiError(e) || '답변 생성 중 오류가 발생했습니다.');
+      setError(apiError(e) || '답변 생성 중 오류가 발생했습니다.'); //에러나면 멘트 띄우기
     } finally {
       setSaving(false);
     }
@@ -306,7 +307,7 @@ function AnswerCard({
 
   return (
     <article className="bg-gs-10 w-[652px] rounded-[16px] p-[32px] mt-[20px] flex flex-col items-start gap-[24px]">
-      {/* 헤더: 상태 배지 + 더보기 */}
+      {/* 헤더 상태, 더보기 */}
       <div className="w-full flex items-center">
         <span
           className={`px-[12px] py-[4px] text-[14px] font-medium border border-solid rounded-[8px] 
@@ -473,7 +474,7 @@ function AnswerCard({
           </div>
         </div>
 
-        {/* 좋아요/싫어요 */}
+        {/* 좋아요 싫어요 버튼, 이 부분은 지우고 컴포넌트 불러와서 사용해도 무방할듯*/}
         <div className="border-t-gs-30 border-t-[1px] w-full pt-[24px] flex gap-[32px] text-[14px] font-medium text-gs-40 mt-[16px]">
           <button
             className={`flex items-center gap-[6px] ${
@@ -499,6 +500,7 @@ function AnswerCard({
   );
 }
 
+//질문 올라온 시간 체크해서 표시
 function timeAgo(iso) {
   const then = new Date(iso).getTime();
   const now = Date.now();

--- a/src/pages/Answer.jsx
+++ b/src/pages/Answer.jsx
@@ -6,11 +6,9 @@ import { getQuestion } from '../api/getQuestion';
 import { getSubjectsId } from '../api/getSubjectsId';
 import { deleteSubjectsId } from '../api/deleteSubjectsId';
 import { createAnswer, deleteAnswer, patchAnswer } from '../api/answers';
-
-// 팀 공용 헤더 + 카드(UI)
+// 프로필 상단 헤더,  카드UI
 import Headers from '../components/question/Headers';
 import AnswerCard from '../components/answer/AnswerCard';
-
 // n개의 질문이 있습니다 앞 아이콘
 import MessagesIcon from '../assets/images/messages.svg?react';
 
@@ -80,7 +78,7 @@ export default function AnswerPage() {
             questionId: q.id,
             question: q.content ?? '(내용 없음)',
             createdAt: q.createdAt ? timeAgo(q.createdAt) : '방금 전',
-            answer: firstAnswer, // { id, content, ... } | null
+            answer: firstAnswer, // { id, content, ... } or null
           };
         });
 

--- a/src/pages/Answer.jsx
+++ b/src/pages/Answer.jsx
@@ -1,3 +1,4 @@
+//8.20 모달작업 dev 머지파일 pull
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 

--- a/src/pages/Answer.jsx
+++ b/src/pages/Answer.jsx
@@ -1,100 +1,234 @@
+// src/pages/Answer.jsx
 import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-// SVG를 React 컴포넌트로 임포트 (svgr)
+// API
+import { getQuestion } from '../api/getQuestion';
+import { getSubjectsId } from '../api/getSubjectsId';
+import { deleteSubjectsId } from '../api/deleteSubjectsId';
+import { createAnswer, deleteAnswer, patchAnswer } from '../api/answers';
+
+// 팀 공용 헤더(배경 + 프로필)
+import Headers from '../components/question/Headers';
+
+// SVG
 import AnswerComplete from '../assets/images/answer_complete.svg?react';
 import AnswerNo from '../assets/images/answer_no.svg?react';
 import CloseIcon from '../assets/images/Close.svg?react';
 import EditIcon from '../assets/images/Edit.svg?react';
-import FacebookIcon from '../assets/images/Facebook.svg?react';
-import KakaoIcon from '../assets/images/Kakaotalk.svg?react';
-import LinkIcon from '../assets/images/Link.svg?react';
-import Logo from '../assets/images/logo.svg?react';
-import HeroBg from '../assets/images/main_bg.svg?react';
-import MessagesIcon from '../assets/images/Messages.svg?react';
+import MessagesIcon from '../assets/images/messages.svg?react';
 import MoreIcon from '../assets/images/More.svg?react';
 import ProfileImg from '../assets/images/profile_img.svg?react';
 import ThumbsDownIcon from '../assets/images/thumbs-down.svg?react';
 import ThumbsUpIcon from '../assets/images/thumbs-up.svg?react';
 
+const apiError = e =>
+  e?.response?.data?.detail ||
+  e?.response?.data?.message ||
+  (typeof e?.response?.data === 'string' ? e.response.data : '') ||
+  e?.message ||
+  '알 수 없는 오류가 발생했습니다.';
+
 export default function Answer() {
+  const navigate = useNavigate();
+  const subjectId =
+    typeof window !== 'undefined' ? localStorage.getItem('id') : null;
+
+  const [userInfo, setUserInfo] = useState(null);
+  const [cards, setCards] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadErr, setLoadErr] = useState('');
+
+  // 훅은 항상 호출되도록 유지, 내부 가드로 빠른 종료
+  useEffect(() => {
+    if (!subjectId) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+
+    (async () => {
+      try {
+        setLoading(true);
+        setLoadErr('');
+
+        const profile = await getSubjectsId(subjectId);
+        if (cancelled) return;
+        setUserInfo({
+          name: profile?.name ?? '내 프로필',
+          imageSource: profile?.imageSource ?? profile?.imageUrl ?? null,
+          questionCount: profile?.questionCount ?? 0,
+        });
+
+        const data = await getQuestion(subjectId);
+        if (cancelled) return;
+        const list = Array.isArray(data) ? data : (data?.results ?? []);
+
+        const normalized = list.map(q => {
+          const firstAnswer =
+            q.answer ??
+            (Array.isArray(q.answers) && q.answers.length > 0
+              ? q.answers[0]
+              : null);
+
+          return {
+            questionId: q.id,
+            question: q.content ?? '(내용 없음)',
+            createdAt: q.createdAt ? timeAgo(q.createdAt) : '방금 전',
+            author: q.authorName ?? q.author?.name ?? '익명', // 질문 작성자(표시는 안 쓰지만 데이터는 유지)
+            answer: firstAnswer,
+          };
+        });
+
+        setCards(normalized);
+      } catch (e) {
+        if (!cancelled) {
+          setLoadErr(apiError(e) || '질문 목록을 불러오지 못했습니다.');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false); // finally 안 return 금지 → 가드로 처리
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [subjectId]);
+
+  const handleDeleteProfile = async () => {
+    if (!subjectId) return;
+    const ok = window.confirm('프로필을 삭제하시겠습니까?');
+    if (!ok) return;
+
+    try {
+      await deleteSubjectsId(subjectId);
+      localStorage.removeItem('id');
+      alert('프로필이 삭제되었습니다.');
+      navigate('/list');
+    } catch (e) {
+      alert(apiError(e));
+    }
+  };
+
   return (
-    <div className="min-h-screen w-full bg-gs-10">
-      {/* 헤더 */}
-      <header className="relative w-full">
-        {/* 배경 SVG를 컴포넌트로 렌더링 */}
-        <HeroBg className="w-full h-[234px]" />
-        {/* 중앙 스택 */}
-        <div className="absolute inset-x-0 top-[50px] z-10 flex flex-col items-center gap-3">
-          {/* 로고 */}
-          <div className="w-[170px] h-[67px] flex items-center justify-center">
-            <Logo className="max-w-full max-h-full" aria-label="OpenMind" />
-          </div>
-          {/* 프로필 */}
-          <div className="w-[136px] h-[136px] rounded-full overflow-hidden ring-4 ring-gs-10 shadow">
-            <ProfileImg className="w-full h-full" aria-label="프로필" />
-          </div>
-          {/* 사용자명 */}
-          <div className="w-[177px] h-[40px] flex items-center justify-center">
-            <span className="text-[18px] font-semibold leading-none text-bn-50">
-              아초는고양이
-            </span>
-          </div>
-          {/* SNS 링크 */}
-          <div className="w-[144px] h-[40px] flex items-center justify-center gap-2 text-gs-50">
-            <LinkIcon className="h-5 w-5 fill-current" aria-hidden />
-            <KakaoIcon className="h-5 w-5 fill-current" aria-hidden />
-            <FacebookIcon className="h-5 w-5 fill-current" aria-hidden />
+    <div className="min-h-screen bg-gs-20 flex flex-direction flex-col items-center">
+      {/* 훅을 조건부 호출하지 않기 위해 렌더링만 조건 처리 */}
+      {!subjectId ? (
+        <div className="min-h-screen flex items-center justify-center bg-gs-20 w-full">
+          <div className="bg-white rounded-xl p-8 shadow text-center">
+            <p className="text-bn-50 mb-4">프로필을 생성해주세요.</p>
+            <button
+              onClick={() => navigate('/')}
+              className="px-4 py-2 rounded-lg bg-bn-40 text-white"
+            >
+              프로필 만들러 가기
+            </button>
           </div>
         </div>
-      </header>
+      ) : (
+        <>
+          <Headers
+            userInfo={
+              userInfo ?? {
+                name: '내 프로필',
+                imageSource: null,
+                questionCount: 0,
+              }
+            }
+          />
 
-      {/* 삭제하기 버튼, 여기서 삭제시 프로필 전체를 삭제(초기화)해버리기 */}
-      <div className="w-full px-[242px] mt-[150px] mb-[10px]">
-        <div className="max-w-[1120px] mx-auto flex justify-end">
-          <div
-            role="button"
-            tabIndex={0}
-            className="w-[100px] h-[35px] rounded-full bg-bn-40 text-gs-10 text-sm font-medium flex items-center justify-center hover:opacity-90"
-          >
-            삭제하기
+          {/* 프로필 삭제 버튼 */}
+          <div className="w-full flex justify-center">
+            <div className="w-[716px] flex justify-end mt-[172px]">
+              <button
+                onClick={handleDeleteProfile}
+                className="px-5 h-[35px] rounded-full bg-bn-40 text-gs-10 text-sm font-medium hover:opacity-90"
+              >
+                삭제하기
+              </button>
+            </div>
           </div>
-        </div>
-      </div>
 
-      {/* 섹션 래퍼 */}
-      <main className="w-full px-[242px] pb-[140px]">
-        <section className="w-full max-w-[1120px] mx-auto rounded-2xl border border-bn-20 bg-bn-10 shadow-sm p-6">
-          <div className="w-[216px] h-[25px] mx-auto text-bn-40 text-[13px] font-semibold flex items-center justify-center gap-1.5 mb-4">
-            <MessagesIcon className="w-4 h-4" aria-hidden />
-            3개의 질문이 있습니다
-          </div>
+          {/* 질문 컨테이너 */}
+          <main className="border-bn-30 rounded-[16px] w-[716px] mt-[8px] mb-[136px] bg-bn-10 border border-solid flex flex-col justify-center items-center">
+            <section className="max-w-[684px] rounded-[16px] p-[16px] w-full">
+              <div className="flex items-center justify-center gap-[8px] mb-[16px]">
+                <MessagesIcon className="fill-bn-40 w-[20px] h-[20px]" />
+                {loading ? (
+                  <h2 className="text-[20px] font-[400] text-bn-40">
+                    불러오는 중…
+                  </h2>
+                ) : (
+                  <h2 className="text-[20px] font-[400] text-bn-40">
+                    {cards.length === 0
+                      ? '아직 질문이 없습니다.'
+                      : `${cards.length}개의 질문이 있습니다.`}
+                  </h2>
+                )}
+              </div>
 
-          {/* 카드들 */}
-          <AnswerCard />
-          <AnswerCard />
-        </section>
-      </main>
+              {loadErr && (
+                <div className="w-full text-center text-red-600 text-sm mb-3">
+                  {loadErr}
+                </div>
+              )}
+
+              {!loading &&
+                cards.map(c => (
+                  <AnswerCard
+                    key={c.questionId}
+                    questionId={c.questionId}
+                    // ✅ 답변자 영역을 메인 프로필로 일치
+                    author={userInfo?.name ?? '내 프로필'}
+                    authorImage={userInfo?.imageSource ?? null}
+                    question={c.question}
+                    createdAt={c.createdAt}
+                    initialAnswer={c.answer}
+                  />
+                ))}
+
+              {!loading && cards.length === 0 && !loadErr && (
+                <div className="w-full text-center text-gs-50 my-6">
+                  등록된 질문이 없습니다.
+                </div>
+              )}
+            </section>
+          </main>
+        </>
+      )}
     </div>
   );
 }
 
-function AnswerCard() {
-  const [text, setText] = useState('');
-  const [savedText, setSavedText] = useState('');
-  const [isAnswered, setIsAnswered] = useState(false);
+function AnswerCard({
+  questionId,
+  author,
+  authorImage, // ✅ 추가: 메인 프로필 이미지
+  question,
+  createdAt,
+  initialAnswer,
+}) {
+  const [answer, setAnswer] = useState(initialAnswer ?? null);
+  useEffect(() => setAnswer(initialAnswer ?? null), [initialAnswer]);
 
-  // 편집 모드
-  const [isEditing, setIsEditing] = useState(false);
+  const [text, setText] = useState('');
   const [editText, setEditText] = useState('');
 
-  // 드롭다운
   const [menuOpen, setMenuOpen] = useState(false);
-  const [selectedAction, setSelectedAction] = useState(null); // 'edit' | 'delete' | null
+  const [mode, setMode] = useState('idle'); // 'idle' | 'editing' | 'confirm-delete'
+  const [vote, setVote] = useState(null);
   const menuRef = useRef(null);
 
-  // 좋아요/싫어요(like, dislike, null)
-  const [vote, setVote] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState('');
 
+  const isAnswered = !!answer;
+
+  // 바깥 클릭 닫기
   useEffect(() => {
     const onClickOutside = e => {
       if (!menuRef.current) return;
@@ -102,229 +236,278 @@ function AnswerCard() {
     };
     if (menuOpen) document.addEventListener('mousedown', onClickOutside);
     return () => document.removeEventListener('mousedown', onClickOutside);
-  }, [menuOpen]);
+  }, [menuOpen, menuRef]);
 
   const toggleMenu = () => setMenuOpen(v => !v);
+  const toggleVote = c => setVote(prev => (prev === c ? null : c));
 
-  const handleSelect = action => {
-    if (action === 'edit' && !isAnswered) return; // 답변 완료 전엔 비활성
-    if (action === 'edit') {
-      setSelectedAction('edit');
-      setEditText(savedText);
-      setIsEditing(true);
-      setMenuOpen(false);
+  const handleCreate = async () => {
+    if (!text.trim() || !questionId) return;
+    try {
+      setSaving(true);
+      setError('');
+      const created = await createAnswer(questionId, {
+        content: text.trim(),
+        isRejected: false,
+      });
+      setAnswer(created);
+      setText('');
+    } catch (e) {
+      setError(apiError(e) || '답변 생성 중 오류가 발생했습니다.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const openEdit = () => {
+    if (!isAnswered) {
+      setError('답변을 작성해주세요.');
       return;
     }
-    if (action === 'delete') {
-      setSelectedAction('delete');
-      setMenuOpen(false);
-      // 삭제 로직 추가하기, 여기서 삭제하면 해당 질문만 삭제하기
+    setEditText(answer.content);
+    setMode('editing');
+    setMenuOpen(false);
+  };
+
+  const handlePatch = async () => {
+    if (!editText.trim() || !answer?.id) return;
+    try {
+      setEditing(true);
+      setError('');
+      const updated = await patchAnswer(answer.id, {
+        content: editText.trim(),
+      });
+      setAnswer(updated);
+      setMode('idle');
+    } catch (e) {
+      setError(apiError(e) || '수정 중 오류가 발생했습니다.');
+    } finally {
+      setEditing(false);
     }
   };
 
-  const handleSubmit = () => {
-    if (!text.trim()) return;
-    setSavedText(text.trim());
-    setIsAnswered(true);
-    setIsEditing(false);
+  const handleDelete = async () => {
+    if (!answer?.id) {
+      setError('삭제할 답변이 없습니다.');
+      return;
+    }
+    try {
+      setDeleting(true);
+      setError('');
+      await deleteAnswer(answer.id);
+      setAnswer(null);
+      setMode('idle');
+    } catch (e) {
+      setError(apiError(e) || '삭제 중 오류가 발생했습니다.');
+    } finally {
+      setDeleting(false);
+    }
   };
-
-  const handleEditSubmit = () => {
-    if (!editText.trim()) return;
-    setSavedText(editText.trim());
-    setIsEditing(false);
-  };
-
-  // 좋아요싫어요 하나만 선택 같은 버튼 두 번 누르면 해제
-  const toggleVote = choice =>
-    setVote(prev => (prev === choice ? null : choice));
 
   return (
-    <article className="mx-auto my-6 w-[684px] rounded-2xl bg-gs-10 ring-1 ring-bn-20 shadow-sm overflow-hidden">
-      <div className="w-full p-8 flex flex-col items-center">
-        <div className="w-[620px] h-[26px] flex items-center justify-between relative">
-          {/* 상태 아이콘 */}
-          {isAnswered ? (
-            <AnswerComplete
-              className="w-[76px] h-[26px]"
-              aria-label="답변완료"
-            />
-          ) : (
-            <AnswerNo className="w-[61px] h-[26px]" aria-label="미답변" />
-          )}
+    <article className="bg-gs-10 w-[652px] rounded-[16px] p-[32px] mt-[20px] flex flex-col items-start gap-[24px]">
+      {/* 헤더: 상태 배지 + 더보기 */}
+      <div className="w-full flex items-center">
+        <span
+          className={`px-[12px] py-[4px] text-[14px] font-medium border border-solid rounded-[8px] 
+            ${isAnswered ? 'text-bn-40 border-bn-40' : 'text-gs-40 border-gs-40'}`}
+        >
+          {isAnswered ? '답변 완료' : '미답변'}
+        </span>
 
-          {/* 더보기 드롭다운 리스트 */}
-          <div className="relative" ref={menuRef}>
-            <button
-              type="button"
-              aria-haspopup="menu"
-              aria-expanded={menuOpen}
-              onClick={toggleMenu}
-              onKeyDown={e =>
-                (e.key === 'Enter' || e.key === ' ') && toggleMenu()
-              }
-              className="h-6 w-6 flex items-center justify-center rounded-full hover:bg-gs-20 cursor-pointer focus:outline-none focus:ring-2 focus:ring-bn-30"
-            >
-              <MoreIcon className="h-4 w-4" aria-hidden />
-            </button>
-
-            {menuOpen && (
-              <div
-                role="menu"
-                aria-label="카드 메뉴"
-                className="absolute right-0 top-8 w-[120px] h-[68px] rounded-md bg-white shadow-md ring-1 ring-gs-30 p-1 z-20 flex flex-col"
-              >
-                {/* 수정하기 */}
-                <button
-                  type="button"
-                  role="menuitem"
-                  onClick={() => handleSelect('edit')}
-                  className={`group flex items-center justify-between gap-2 h-[34px] w-full rounded-[6px] px-2 text-[13px]
-                    ${selectedAction === 'edit' ? 'text-b50' : 'text-gs-50'}
-                    hover:bg-gs-20 hover:text-bn-50 focus:outline-none`}
-                >
-                  <span className="inline-flex items-center gap-2">
-                    <EditIcon className="w-4 h-4" aria-hidden />
-                    수정하기
-                  </span>
-                </button>
-
-                {/* 삭제하기, 여기서 삭제하면 해당 질문만 삭제하기*/}
-                <button
-                  type="button"
-                  role="menuitem"
-                  onClick={() => handleSelect('delete')}
-                  className={`group flex items-center justify-between gap-2 h-[34px] w-full rounded-[6px] px-2 text-[13px]
-                    ${selectedAction === 'delete' ? 'text-b50' : 'text-gs-50'}
-                    hover:bg-gs-20 hover:text-bn-50 focus:outline-none`}
-                >
-                  <span className="inline-flex items-center gap-2">
-                    <CloseIcon className="w-4 h-4" aria-hidden />
-                    삭제하기
-                  </span>
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* 질문 영역 */}
-        <div className="w-[620px] mt-4">
-          <div className="text-[12px] text-gs-40">질문 · 2주전</div>
-          <div className="mt-1 text-[18px] font-semibold text-bn-50 leading-6">
-            좋아하는 동물은?
-          </div>
-        </div>
-
-        {/* 본문 */}
-        <div className="w-[620px] mt-4">
-          <div className="flex gap-3">
-            <div className="h-12 w-12 rounded-full overflow-hidden bg-bn-20 flex-shrink-0">
-              <ProfileImg className="w-full h-full" aria-hidden />
-            </div>
-
-            <div className="flex-1">
-              <div className="text-[14px] font-medium mb-2 text-bn-50">
-                아초는고양이
-              </div>
-
-              <div className="w-[520px]">
-                {!isAnswered && !isEditing && (
-                  <textarea
-                    value={text}
-                    onChange={e => setText(e.target.value)}
-                    placeholder="답변을 입력해주세요"
-                    className="min-h-[120px] w-full resize-none rounded-lg bg-gs-20 border border-gs-30 px-3 py-2 text-[14px] text-gs-50 outline-none"
-                  />
-                )}
-
-                {isAnswered && !isEditing && (
-                  <div
-                    className="w-full px-1 py-1 text-[14px] text-bn-50 whitespace-pre-wrap"
-                    aria-label="작성한 답변"
-                  >
-                    {savedText}
-                  </div>
-                )}
-
-                {isEditing && (
-                  <textarea
-                    value={editText}
-                    onChange={e => setEditText(e.target.value)}
-                    placeholder="답변을 수정해주세요"
-                    className="min-h-[120px] w-full resize-none rounded-lg bg-gs-20 border border-gs-30 px-3 py-2 text-[14px] text-gs-50 outline-none"
-                  />
-                )}
-              </div>
-            </div>
-          </div>
-
-          {/* 하단 버튼 */}
-          {!isAnswered && !isEditing && (
-            <div className="ml-[60px] mt-4">
-              <button
-                type="button"
-                className={`w-[520px] h-11 rounded-lg flex items-center justify-center text-[14px] font-semibold ${
-                  text.trim()
-                    ? 'bg-bn-40 text-gs-10 cursor-pointer'
-                    : 'bg-bn-30 text-gs-10/80 cursor-not-allowed'
-                }`}
-                disabled={!text.trim()}
-                onClick={handleSubmit}
-              >
-                답변 완료
-              </button>
-            </div>
-          )}
-
-          {isEditing && (
-            <div className="ml-[60px] mt-4">
-              <button
-                type="button"
-                className={`w-[520px] h-11 rounded-lg flex items-center justify-center text-[14px] font-semibold ${
-                  editText.trim()
-                    ? 'bg-bn-40 text-gs-10 cursor-pointer'
-                    : 'bg-bn-30 text-gs-10/80 cursor-not-allowed'
-                }`}
-                disabled={!editText.trim()}
-                onClick={handleEditSubmit}
-              >
-                수정 완료
-              </button>
-            </div>
-          )}
-        </div>
-
-        {/* 구분선 */}
-        <div className="w-[620px] mt-6 border-t border-gs-30" />
-
-        {/* 좋아요/싫어요 — SVG가 currentColor를 따라 색 변경 */}
-        <div className="w-[620px] mt-3 flex items-center gap-3">
+        <div className="ml-auto relative" ref={menuRef}>
           <button
             type="button"
-            onClick={() => toggleVote('like')}
-            className={`h-9 px-3 inline-flex items-center gap-2 rounded-lg text-[14px] ${
-              vote === 'like' ? 'text-b50' : 'text-gs-60'
-            }`}
-            aria-pressed={vote === 'like'}
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            onClick={toggleMenu}
+            onKeyDown={e =>
+              (e.key === 'Enter' || e.key === ' ') && toggleMenu()
+            }
+            className="h-6 w-6 flex items-center justify-center rounded-full hover:bg-gs-20 cursor-pointer focus:outline-none focus:ring-2 focus:ring-bn-30"
           >
-            <ThumbsUpIcon className="w-4 h-4 fill-current stroke-current" />
-            좋아요
+            <MoreIcon className="h-4 w-4" aria-hidden />
           </button>
 
+          {menuOpen && (
+            <div
+              role="menu"
+              aria-label="카드 메뉴"
+              className="absolute right-0 top-8 w-[140px] rounded-md bg-white shadow-md ring-1 ring-gs-30 p-1 z-20 flex flex-col"
+            >
+              <button
+                type="button"
+                role="menuitem"
+                onClick={openEdit}
+                className="group flex items-center gap-2 h-[34px] w-full rounded-[6px] px-2 text-[13px] text-gs-50 hover:bg-gs-20 hover:text-bn-50"
+              >
+                <EditIcon className="w-4 h-4" aria-hidden />
+                수정하기
+              </button>
+
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  if (!isAnswered) {
+                    setError('삭제할 답변이 없습니다.');
+                    setMenuOpen(false);
+                    return;
+                  }
+                  setMode('confirm-delete');
+                  setMenuOpen(false);
+                }}
+                className="group flex items-center gap-2 h-[34px] w-full rounded-[6px] px-2 text-[13px] text-gs-50 hover:bg-gs-20 hover:text-bn-50"
+              >
+                <CloseIcon className="w-4 h-4" aria-hidden />
+                답변 삭제
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 질문 */}
+      <div className="flex flex-col gap-[4px]">
+        <p className="text-[14px] font-medium text-gs-40">질문 · {createdAt}</p>
+        <p className="text-[18px] font-normal">{question}</p>
+      </div>
+
+      {/* 본문 */}
+      <div className="w-full">
+        <div className="flex gap-[12px]">
+          {authorImage ? (
+            <img
+              src={authorImage}
+              alt={`${author} 프로필`}
+              className="w-[48px] h-[48px] rounded-full object-cover"
+            />
+          ) : (
+            <ProfileImg className="w-[48px] h-[48px]" />
+          )}
+          <div className="flex-1 flex flex-col gap-[8px]">
+            <p className="text-[18px] font-normal">{author}</p>
+
+            {!isAnswered && mode !== 'editing' && (
+              <textarea
+                value={text}
+                onChange={e => setText(e.target.value)}
+                placeholder="답변을 입력해주세요"
+                className="min-h-[120px] w-full resize-none rounded-lg bg-gs-20 border border-gs-30 px-3 py-2 text-[14px] text-gs-50 outline-none"
+              />
+            )}
+
+            {isAnswered && mode !== 'editing' && (
+              <div className="text-[16px] whitespace-pre-wrap">
+                {answer.content}
+              </div>
+            )}
+
+            {mode === 'editing' && (
+              <textarea
+                value={editText}
+                onChange={e => setEditText(e.target.value)}
+                placeholder="답변을 수정해주세요"
+                className="min-h-[120px] w-full resize-none rounded-lg bg-gs-20 border border-gs-30 px-3 py-2 text-[14px] text-gs-50 outline-none"
+              />
+            )}
+
+            {/* 버튼 */}
+            <div className="mt-[16px] w-full">
+              {!isAnswered &&
+                mode !== 'editing' &&
+                mode !== 'confirm-delete' && (
+                  <button
+                    type="button"
+                    onClick={handleCreate}
+                    disabled={!text.trim() || saving}
+                    className={`w-full h-11 rounded-lg flex items-center justify-center text-[14px] font-semibold ${
+                      text.trim() && !saving
+                        ? 'bg-bn-40 text-gs-10'
+                        : 'bg-bn-30 text-gs-10/80 cursor-not-allowed'
+                    }`}
+                  >
+                    {saving ? '저장 중…' : '답변 완료'}
+                  </button>
+                )}
+
+              {mode === 'editing' && (
+                <button
+                  type="button"
+                  onClick={handlePatch}
+                  disabled={!editText.trim() || editing}
+                  className={`w-full h-11 rounded-lg flex items-center justify-center text-[14px] font-semibold ${
+                    editText.trim() && !editing
+                      ? 'bg-bn-40 text-gs-10'
+                      : 'bg-bn-30 text-gs-10/80 cursor-not-allowed'
+                  }`}
+                >
+                  {editing ? '수정 중…' : '수정 완료'}
+                </button>
+              )}
+
+              {mode === 'confirm-delete' && (
+                <div className="w-full flex flex-col gap-2">
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    disabled={deleting}
+                    className="w-full h-11 rounded-lg bg-red-500 text-white text-[14px] font-semibold hover:opacity-90"
+                  >
+                    {deleting ? '삭제 중…' : '답변을 삭제하시겠습니까?'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setMode('idle')}
+                    className="w-full h-11 rounded-lg border border-gs-30 text-[14px]"
+                  >
+                    취소
+                  </button>
+                </div>
+              )}
+
+              {error && (
+                <div className="mt-3 text-[13px] text-red-600">{error}</div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* 좋아요/싫어요 */}
+        <div className="border-t-gs-30 border-t-[1px] w-full pt-[24px] flex gap-[32px] text-[14px] font-medium text-gs-40 mt-[16px]">
           <button
-            type="button"
-            onClick={() => toggleVote('dislike')}
-            className={`h-9 px-3 inline-flex items-center gap-2 rounded-lg text-[14px] ${
-              vote === 'dislike' ? 'text-b50' : 'text-gs-60'
+            className={`flex items-center gap-[6px] ${
+              vote === 'like' ? 'text-bn-40' : ''
             }`}
-            aria-pressed={vote === 'dislike'}
+            onClick={() => toggleVote('like')}
           >
-            <ThumbsDownIcon className="w-4 h-4 fill-current stroke-current" />
-            싫어요
+            <ThumbsUpIcon className="w-[16px] h-[16px]" />
+            <p>좋아요</p>
+          </button>
+          <button
+            className={`flex items-center gap-[6px] ${
+              vote === 'dislike' ? 'text-bn-40' : ''
+            }`}
+            onClick={() => toggleVote('dislike')}
+          >
+            <ThumbsDownIcon className="w-[16px] h-[16px]" />
+            <p>싫어요</p>
           </button>
         </div>
       </div>
     </article>
   );
+}
+
+function timeAgo(iso) {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diff = Math.max(0, now - then);
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return '방금 전';
+  if (m < 60) return `${m}분 전`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}시간 전`;
+  const d = Math.floor(h / 24);
+  return `${d}일 전`;
 }


### PR DESCRIPTION
## 📌 PR 제목

답변하기 api 연동

## 📝 작업 내용

1. 메인페이지에서 생성한 프로필 연동
2. 질문리스트에서 생성한 프로필에 추가된 질문 가져오기
(답변하기 페이지로 이동하면 내 프로필에 달린 질문 리스트 확인)
3. 더보기(...)버튼에서 입력한 답변 삭제기능, 삭제 재확인 및 취소 버튼 ui 추가 (바로 삭제되는건 너무 가차없는것 같아서..)
4. 답변하기 페이지 상단에 삭제하기 버튼을 누르면 프로필 삭제 구현
5. 기타 프로필이 확인되지 않은 상태에서 답변하기로 들어가게 되는 경우 메인 페이지로 이동

## 🔍 주요 변경 사항

작업내용이랑 동일합니다
제가 만든 답변하기 헤더 ui가 계속 깨져서 개별피드 헤더를 가져와서 사용했습니다

## 💬 기타 참고 사항


