### PR TITLE
refactor: 토스트 UI를 페이지 레벨로 이동(AnswerQuestion)

### DIFF
--- a/src/components/Modal/QuestionModal.jsx
+++ b/src/components/Modal/QuestionModal.jsx
@@ -1,4 +1,3 @@
-// src/components/Modal/QuestionModal.jsx (정리/가독성 개선 버전)
 import React, {
   useEffect,
   useMemo,
@@ -7,22 +6,12 @@ import React, {
   useCallback,
 } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { motion, AnimatePresence } from 'framer-motion';
 import instance from '../../api/ApiAxios.js';
 import profileImg from '../../assets/images/profile_img.svg';
 
-/**
- * 기능 요약
- * 1) 모달 열림/닫힘
- * 2) 입력값에 따라 전송 버튼 활성화
- * 3) POST /subjects/:id/questions/ 연동
- * 4) 성공 시 토스트 → 리스트 자동 갱신(soft reload)
- * 5) FloatingButton → window 'open-question-modal' 이벤트로 열림
- * 6) To. 라인: props > 서버데이터 > 기본이미지/기본이름
- */
 export default function QuestionModal({
   subjectId = null, // 외부에서 명시적으로 넘겨주는 subjectId(최우선)
-  onSent, // 성공 후 부모 갱신 콜백(선택)
+  onSent, // 성공 후 부모가 토스트/갱신 처리
   subjectName, // 외부에서 넘겨주는 대상 이름(선택)
   subjectAvatarUrl, // 외부에서 넘겨주는 대상 아바타 URL(선택)
 }) {
@@ -34,7 +23,6 @@ export default function QuestionModal({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [question, setQuestion] = useState('');
   const [loading, setLoading] = useState(false);
-  const [showSuccess, setShowSuccess] = useState(false);
 
   // 대상 정보(서버) & 로딩
   const [subjectInfo, setSubjectInfo] = useState(null); // { name, imageSource, ... } (키명은 API에 따름)
@@ -137,9 +125,6 @@ export default function QuestionModal({
       setQuestion('');
       setIsModalOpen(false);
 
-      // 성공 토스트 → 잠시 노출 후 소프트 리로드
-      setShowSuccess(true);
-
       // 부모 콜백(onSent)이 있으면 먼저 호출 (실패해도 무시)
       try {
         if (typeof onSent === 'function') onSent();
@@ -147,15 +132,14 @@ export default function QuestionModal({
         /* noop */
       }
 
-      // 토스트 노출 후 자동 갱신(soft reload) 보장
-      setTimeout(() => {
-        setShowSuccess(false);
+      // 부모가 콜백을 안 줬을 때만(예외) 안전하게 새로고침
+      if (typeof onSent !== 'function') {
         try {
           navigate(0);
         } catch {
           window.location.reload();
         }
-      }, 1000);
+      }
     } catch (err) {
       console.error('질문 전송 실패:', err);
       alert('질문 전송에 실패했어요. 잠시 후 다시 시도해주세요.');
@@ -174,7 +158,7 @@ export default function QuestionModal({
         >
           <div
             className="
-              w-[92%] max-w-[640px]
+              w-full max-w-[640px]
               max-h-[85vh] overflow-auto
               rounded-2xl bg-white p-6
               shadow-[0_12px_30px_rgba(0,0,0,0.25)]
@@ -236,7 +220,7 @@ export default function QuestionModal({
               <button
                 onClick={handleSend}
                 disabled={!canSend}
-                className={`h-12 w-full rounded-xl font-bold text-white transition ${
+                className={`h-12 w-full rounded-xl font-bold text-white ${
                   canSend
                     ? 'bg-[#6B4A2D] hover:brightness-110'
                     : 'cursor-not-allowed bg-[#D6CCC6]'
@@ -248,26 +232,6 @@ export default function QuestionModal({
           </div>
         </div>
       )}
-
-      {/* 성공 토스트 (하단 중앙) */}
-      <AnimatePresence>
-        {showSuccess && (
-          <div className="fixed inset-x-0 bottom-6 flex justify-center z-[60] pointer-events-none">
-            <motion.div
-              key="toast"
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 10 }}
-              transition={{ duration: 0.25 }}
-              className="rounded-lg px-4 py-3 bg-bn-40 text-white shadow-lg pointer-events-auto"
-              role="status"
-              aria-live="polite"
-            >
-              질문이 생성되었습니다!
-            </motion.div>
-          </div>
-        )}
-      </AnimatePresence>
     </>
   );
 }

--- a/src/pages/AnswerQuestion.jsx
+++ b/src/pages/AnswerQuestion.jsx
@@ -1,3 +1,5 @@
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import QuestionFeedList from '../components/question/QuestionFeedList';
 import Headers from '../components/question/Headers';
 import FloatingButton from '../components/question/FloatingButton';
@@ -10,6 +12,14 @@ function AnswerQuestion() {
   const { userInfo, loading, error } = useUserInfo();
   const { questionList, moreNext, isLoading, loadMoreQuestions } =
     useInfiniteScroll(userInfo?.id);
+
+  const [showToast, setShowToast] = useState(false);
+
+  useEffect(() => {
+    if (!showToast) return;
+    const t = setTimeout(() => setShowToast(false), 1200);
+    return () => clearTimeout(t);
+  }, [showToast]);
 
   const observerRef = useRef();
 
@@ -41,7 +51,27 @@ function AnswerQuestion() {
       <QuestionFeedList userInfo={userInfo} questions={questionList} />
       <div ref={observer} />
       <FloatingButton />
-      <QuestionModal />
+      <QuestionModal onSent={() => setShowToast(true)} />
+
+      {/* 페이지 레벨 토스트 */}
+      <AnimatePresence>
+        {showToast && (
+          <div className="fixed inset-x-0 bottom-6 flex justify-center z-[60] pointer-events-none">
+            <motion.div
+              key="toast"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 10 }}
+              transition={{ duration: 0.25 }}
+              className="rounded-lg px-4 py-3 bg-bn-40 text-white shadow-lg pointer-events-auto"
+              role="status"
+              aria-live="polite"
+            >
+              질문이 생성되었습니다!
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }


### PR DESCRIPTION
## 📌 PR 제목

refactor: 토스트 UI를 페이지 레벨로 이동(AnswerQuestion)

## 📝 작업 내용

- 모달 내부에 있던 성공 토스트를 페이지(AnswerQuestion)로 이동하여 UI 책임 분리

## 🔍 주요 변경 사항

- 토스트 UI 관리 주체: Modal → AnswerQuestion

- 토스트 상태(showToast)를 페이지에서 제어

## 💬 기타 참고 사항

<!-- 리뷰어가 참고해야 할 추가 내용 -->
