### PR TITLE
✨ feat : 질문 삭제, 답변 삭제, 수정하기 케밥버튼 수정

### DIFF
--- a/src/api/getQuestion.js
+++ b/src/api/getQuestion.js
@@ -1,13 +1,36 @@
+// import instance from './ApiAxios';
+
+// export const getQuestion = async subjectid => {
+//   const response = await instance.get(`/subjects/${subjectid}/questions/`);
+//   return response.data;
+// };
+
+// export const getQuestionList = async (subjectId, limit = 8, offset = 0) => {
+//   const response = await instance.get(
+//     `/subjects/${subjectId}/questions/?limit=${limit}&offset=${offset}`
+//   );
+//   return response.data;
+// };
+
+// src/api/getQuestion.js
 import instance from './ApiAxios';
 
-export const getQuestion = async subjectid => {
-  const response = await instance.get(`/subjects/${subjectid}/questions/`);
+// 특정 subjectId의 질문 전체 조회
+export const getQuestion = async subjectId => {
+  const response = await instance.get(`/subjects/${subjectId}/questions/`);
   return response.data;
 };
 
+// 페이징 지원 질문 목록 조회
 export const getQuestionList = async (subjectId, limit = 8, offset = 0) => {
   const response = await instance.get(
     `/subjects/${subjectId}/questions/?limit=${limit}&offset=${offset}`
   );
   return response.data;
+};
+
+// ✅ 질문 삭제 (엔드포인트: DELETE /questions/{questionId}/)
+export const deleteQuestion = async questionId => {
+  const response = await instance.delete(`/questions/${questionId}/`);
+  return response.data; // 204면 undefined일 수 있음 (호출부에서 결과 사용 X)
 };

--- a/src/api/getQuestion.js
+++ b/src/api/getQuestion.js
@@ -1,18 +1,3 @@
-// import instance from './ApiAxios';
-
-// export const getQuestion = async subjectid => {
-//   const response = await instance.get(`/subjects/${subjectid}/questions/`);
-//   return response.data;
-// };
-
-// export const getQuestionList = async (subjectId, limit = 8, offset = 0) => {
-//   const response = await instance.get(
-//     `/subjects/${subjectId}/questions/?limit=${limit}&offset=${offset}`
-//   );
-//   return response.data;
-// };
-
-// src/api/getQuestion.js
 import instance from './ApiAxios';
 
 // 특정 subjectId의 질문 전체 조회
@@ -29,8 +14,8 @@ export const getQuestionList = async (subjectId, limit = 8, offset = 0) => {
   return response.data;
 };
 
-// ✅ 질문 삭제 (엔드포인트: DELETE /questions/{questionId}/)
+// 질문 삭제 (엔드포인트: DELETE /questions/{questionId}/)
 export const deleteQuestion = async questionId => {
   const response = await instance.delete(`/questions/${questionId}/`);
-  return response.data; // 204면 undefined일 수 있음 (호출부에서 결과 사용 X)
+  return response.data;
 };

--- a/src/components/Answer/AnswerCard.jsx
+++ b/src/components/Answer/AnswerCard.jsx
@@ -15,12 +15,12 @@ export default function AnswerCard({
   answer,
   like = 0,
   dislike = 0,
-  onCreate,
-  onEdit,
-  onDelete, // (선택) 답변 삭제 계속 쓰면 유지
-  onDeleteQuestion, // ✅ 질문 삭제 콜백(부모에서 전달)
+  onCreate, // 답변 생성
+  onEdit, // 답변 수정
+  onDelete, // 답변 삭제
+  onDeleteQuestion, // 질문 삭제
 }) {
-  const [mode, setMode] = useState('idle'); // 'idle' | 'editing' | 'confirm-delete'
+  const [mode, setMode] = useState('idle');
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef(null);
 
@@ -28,23 +28,23 @@ export default function AnswerCard({
   const [editText, setEditText] = useState('');
   const [saving, setSaving] = useState(false);
   const [editing, setEditing] = useState(false);
+
   const [deleting, setDeleting] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState(null);
   const [error, setError] = useState('');
 
   const isAnswered = !!answer;
 
-  // 수정 UX 보조
+  // 답변수정전, 수정후 비교
   const originalContent = (answer?.content ?? '').trim();
   const editedContent = editText.trim();
   const isEditedChanged = editedContent !== originalContent;
   const canSubmitEdit = isEditedChanged && editedContent.length > 0 && !editing;
 
-  // 답변 있을 때 편집창 동기화
   useEffect(() => {
     if (isAnswered) setEditText(answer?.content ?? '');
   }, [isAnswered, answer?.content]);
 
-  // 메뉴 외부 클릭 닫기
   useEffect(() => {
     const onClickOutside = e => {
       if (!menuRef.current) return;
@@ -88,14 +88,31 @@ export default function AnswerCard({
     }
   };
 
-  // ✅ 질문 삭제
+  // 답변 삭제
+  const handleDeleteAnswer = async () => {
+    if (!answer?.id || !onDelete) return;
+    try {
+      setDeleting(true);
+      setError('');
+      await onDelete(answer.id); // 부모 호출 후 answer에 null값 반영
+      setMode('idle');
+      setDeleteTarget(null);
+    } catch (e) {
+      setError(e?.message || '답변 삭제 중 오류가 발생했습니다.');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  // 질문 삭제
   const handleDeleteQuestion = async () => {
     if (!questionId || !onDeleteQuestion) return;
     try {
       setDeleting(true);
       setError('');
-      await onDeleteQuestion(questionId); // 부모에서 서버 호출 + 리스트 제거
+      await onDeleteQuestion(questionId); // 부모 호출 후 리스트 삭제
       setMode('idle');
+      setDeleteTarget(null);
     } catch (e) {
       setError(e?.message || '질문 삭제 중 오류가 발생했습니다.');
     } finally {
@@ -105,7 +122,6 @@ export default function AnswerCard({
 
   return (
     <article className="bg-gs-10 w-full max-w-[652px] rounded-[16px] p-8 md:p-[32px] mt-[20px] flex flex-col items-start gap-[24px]">
-      {/* 상단: 상태 배지 + 케밥 메뉴 */}
       <div className="w-full flex items-center">
         <span
           className={`px-[12px] py-[4px] text-[14px] font-medium border border-solid rounded-[8px] ${
@@ -133,33 +149,56 @@ export default function AnswerCard({
             <div
               role="menu"
               aria-label="카드 메뉴"
-              className="absolute right-0 top-8 w-[140px] rounded-md bg-white shadow-md ring-1 ring-gs-30 p-1 z-20 flex flex-col"
+              className="absolute right-0 top-8 w-[160px] rounded-md bg-white shadow-md ring-1 ring-gs-30 p-1 z-20 flex flex-col"
             >
-              {/* 답변 수정(답변 있을 때만) */}
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  if (!isAnswered) return;
-                  setEditText(answer?.content ?? '');
-                  setMode('editing');
-                  setMenuOpen(false);
-                }}
-                className="group flex items-center gap-2 h-[34px] w-full rounded-[6px] px-2 text-[13px] text-gs-50 hover:bg-gs-20 hover:text-bn-50"
-              >
-                <EditIcon className="w-4 h-4" aria-hidden />
-                수정하기
-              </button>
+              {/* 수정하기, 답변삭제 답변이 있을 때만 활성화 조건 */}
+              {isAnswered && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    if (!isAnswered) return;
+                    setEditText(answer?.content ?? '');
+                    setMode('editing');
+                    setMenuOpen(false);
+                  }}
+                  className={`group flex items-center gap-2 h-[34px] w-full rounded-[6px] px-2 text-[13px] ${
+                    isAnswered
+                      ? 'text-gs-50 hover:bg-gs-20 hover:text-b50'
+                      : 'text-gs-30 cursor-not-allowed'
+                  }`}
+                >
+                  <EditIcon className="w-4 h-4" aria-hidden />
+                  수정하기
+                </button>
+              )}
 
-              {/* ✅ 질문 삭제(답변 유무와 무관하게 허용) */}
+              {isAnswered && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setDeleteTarget('answer');
+                    setMode('confirm-delete');
+                    setMenuOpen(false);
+                  }}
+                  className="group flex items-center gap-2 h-[34px] w-full rounded-[6px] px-2 text-[13px] text-gs-50 hover:bg-gs-20 hover:text-b50"
+                >
+                  <CloseIcon className="w-4 h-4" aria-hidden />
+                  답변삭제
+                </button>
+              )}
+
+              {/* 질문삭제는 항시 활성화 */}
               <button
                 type="button"
                 role="menuitem"
                 onClick={() => {
+                  setDeleteTarget('question');
                   setMode('confirm-delete');
                   setMenuOpen(false);
                 }}
-                className="group flex items-center gap-2 h-[34px] w-full rounded-[6px] px-2 text-[13px] text-gs-50 hover:bg-gs-20 hover:text-bn-50"
+                className="group flex items-center gap-2 h-[34px] w-full rounded-[6px] px-2 text-[13px] text-gs-50 hover:bg-gs-20 hover:text-b50"
               >
                 <CloseIcon className="w-4 h-4" aria-hidden />
                 질문삭제
@@ -169,13 +208,11 @@ export default function AnswerCard({
         </div>
       </div>
 
-      {/* 질문 본문 */}
       <div className="flex flex-col gap-[4px]">
         <p className="text-[14px] font-medium text-gs-40">질문 · {createdAt}</p>
         <p className="text-[18px] font-normal break-anywhere">{question}</p>
       </div>
 
-      {/* 답변 입력/표시 + 액션 */}
       <div className="w-full">
         <div className="flex gap-[12px]">
           {authorImage ? (
@@ -190,7 +227,7 @@ export default function AnswerCard({
           <div className="flex-1 flex flex-col gap-[8px] min-w-0">
             <p className="text-[18px] font-normal">{author}</p>
 
-            {/* 미답변 + 편집 모드 아님 → 새 답변 입력 */}
+            {/* 미답변 + 편집 모드 아닐 때 새 답변 */}
             {!isAnswered && mode !== 'editing' && (
               <textarea
                 value={text}
@@ -200,14 +237,13 @@ export default function AnswerCard({
               />
             )}
 
-            {/* 답변 있음 + 편집 모드 아님 → 읽기 표시 */}
+            {/* 답변 있음 + 편집 모드 아닐 때 읽기 전용 */}
             {isAnswered && mode !== 'editing' && (
               <div className="text-[16px] whitespace-pre-wrap break-anywhere">
                 {answer.content}
               </div>
             )}
 
-            {/* 편집 모드 → 수정 입력 */}
             {mode === 'editing' && (
               <textarea
                 value={editText}
@@ -217,7 +253,6 @@ export default function AnswerCard({
               />
             )}
 
-            {/* 액션 버튼 영역 */}
             <div className="mt-[16px] w-full">
               {/* 답변 생성 */}
               {!isAnswered &&
@@ -262,20 +297,31 @@ export default function AnswerCard({
                 </div>
               )}
 
-              {/* ✅ 질문 삭제 확인 */}
+              {/* 삭제 확인 */}
               {mode === 'confirm-delete' && (
                 <div className="w-full flex flex-col gap-2">
                   <button
                     type="button"
-                    onClick={handleDeleteQuestion}
+                    onClick={
+                      deleteTarget === 'answer'
+                        ? handleDeleteAnswer
+                        : handleDeleteQuestion
+                    }
                     disabled={deleting}
                     className="w-full h-11 rounded-lg bg-r50 text-white text-[14px] font-semibold hover:opacity-90"
                   >
-                    {deleting ? '삭제 중…' : '질문을 삭제하시겠습니까?'}
+                    {deleting
+                      ? '삭제 중…'
+                      : deleteTarget === 'answer'
+                        ? '답변을 삭제하시겠습니까?'
+                        : '질문을 삭제하시겠습니까?'}
                   </button>
                   <button
                     type="button"
-                    onClick={() => setMode('idle')}
+                    onClick={() => {
+                      setMode('idle');
+                      setDeleteTarget(null);
+                    }}
                     className="w-full h-11 rounded-lg border border-gs-30 text-[14px]"
                   >
                     취소
@@ -290,7 +336,7 @@ export default function AnswerCard({
           </div>
         </div>
 
-        {/* 좋아요/싫어요 표기(읽기 전용) */}
+        {/* 좋아요/싫어요 불러와서 읽기 */}
         <LikeButtonViewOnly
           questionId={questionId}
           like={like}

--- a/src/pages/Answer.jsx
+++ b/src/pages/Answer.jsx
@@ -1,11 +1,18 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+// API
 import { getSubjectsId } from '../api/getSubjectsId';
 import { deleteSubjectsId } from '../api/deleteSubjectsId';
 import { createAnswer, deleteAnswer, patchAnswer } from '../api/answers';
+import { deleteQuestion as deleteQuestionApi } from '../api/getQuestion'; // ✅ DELETE /questions/{questionId}/
+
+// 컴포넌트
 import Headers from '../components/question/Headers';
 import AnswerCard from '../components/Answer/AnswerCard';
 import MessagesIcon from '../assets/images/Messages.svg?react';
+
+// 훅
 import useInfiniteScroll from '../hook/useInfiniteScroll';
 
 const apiError = e =>
@@ -131,6 +138,7 @@ export default function AnswerPage() {
     }
   };
 
+  // 답변 생성
   const onCreateAnswer = async (questionId, content) => {
     try {
       const created = await createAnswer(questionId, {
@@ -148,6 +156,7 @@ export default function AnswerPage() {
     }
   };
 
+  // 답변 수정
   const onEditAnswer = async (answerId, content) => {
     try {
       const updated = await patchAnswer(answerId, { content });
@@ -162,6 +171,7 @@ export default function AnswerPage() {
     }
   };
 
+  // 답변 삭제(선택적으로 유지)
   const onDeleteAnswer = async answerId => {
     try {
       await deleteAnswer(answerId);
@@ -170,6 +180,16 @@ export default function AnswerPage() {
           item.answer?.id === answerId ? { ...item, answer: null } : item
         )
       );
+    } catch (e) {
+      throw new Error(apiError(e));
+    }
+  };
+
+  // ✅ 질문 삭제: DELETE /questions/{questionId}/
+  const onDeleteQuestion = async questionId => {
+    try {
+      await deleteQuestionApi(questionId);
+      setQuestionList(prev => prev.filter(item => item.id !== questionId));
     } catch (e) {
       throw new Error(apiError(e));
     }
@@ -281,7 +301,8 @@ export default function AnswerPage() {
                     dislike={c.dislike}
                     onCreate={onCreateAnswer}
                     onEdit={onEditAnswer}
-                    onDelete={onDeleteAnswer}
+                    onDelete={onDeleteAnswer} // (선택) 답변 삭제 유지
+                    onDeleteQuestion={onDeleteQuestion} // ✅ 질문 삭제 콜백 전달
                   />
                 ))}
 

--- a/src/pages/Answer.jsx
+++ b/src/pages/Answer.jsx
@@ -1,19 +1,16 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-// API
-import { getSubjectsId } from '../api/getSubjectsId';
-import { deleteSubjectsId } from '../api/deleteSubjectsId';
+import { getSubjectsId } from '../api/getSubjectsId'; //프로필 정보 (이름, 사진, 질문)
+import { deleteSubjectsId } from '../api/deleteSubjectsId'; //프로필 삭제하기 누르면 얘를 지움
 import { createAnswer, deleteAnswer, patchAnswer } from '../api/answers';
-import { deleteQuestion as deleteQuestionApi } from '../api/getQuestion'; // ✅ DELETE /questions/{questionId}/
+// 질문삭제 api 추가 DELETE /questions/{questionId}, api 엔드포인트
+import { deleteQuestion as deleteQuestionApi } from '../api/getQuestion';
 
-// 컴포넌트
 import Headers from '../components/question/Headers';
+import useInfiniteScroll from '../hook/useInfiniteScroll';
 import AnswerCard from '../components/Answer/AnswerCard';
 import MessagesIcon from '../assets/images/Messages.svg?react';
-
-// 훅
-import useInfiniteScroll from '../hook/useInfiniteScroll';
 
 const apiError = e =>
   e?.response?.data?.detail ||
@@ -39,7 +36,7 @@ export default function AnswerPage() {
   const navigate = useNavigate();
   const subjectId =
     typeof window !== 'undefined' ? localStorage.getItem('id') : null;
-
+  const [liveTotal, setLiveTotal] = useState(null); //질문 삭제하면 실시간으로 질문개수 반영
   const [userInfo, setUserInfo] = useState(null);
   const [loadingProfile, setLoadingProfile] = useState(true);
   const [loadErr, setLoadErr] = useState('');
@@ -55,7 +52,17 @@ export default function AnswerPage() {
 
   const loadMoreRef = useRef(null);
 
-  // 프로필(질문 총 개수 포함) 불러오기
+  //질문 카운트 동기화시키기
+  useEffect(() => {
+    const serverTotal =
+      (typeof totalCount === 'number' ? totalCount : null) ??
+      (typeof userInfo?.questionCount === 'number'
+        ? userInfo.questionCount
+        : null);
+    if (serverTotal !== null) setLiveTotal(serverTotal);
+  }, [totalCount, userInfo?.questionCount]);
+
+  //메인에서 생성한 프로필 + 질문정보 가져오기
   useEffect(() => {
     if (!subjectId) {
       setLoadingProfile(false);
@@ -108,6 +115,7 @@ export default function AnswerPage() {
   const [deletingProfile, setDeletingProfile] = useState(false);
   const [deleteErr, setDeleteErr] = useState('');
 
+  //삭제 모달, overflow를 히든으로 삭제모달 띄웠을 때 스크롤 막기
   useEffect(() => {
     if (!showDeleteModal) return;
     const onKey = e => {
@@ -127,7 +135,7 @@ export default function AnswerPage() {
     try {
       setDeletingProfile(true);
       setDeleteErr('');
-      await deleteSubjectsId(subjectId);
+      await deleteSubjectsId(subjectId); //프로필정보, 질문, 답변 싸그리 지움
       localStorage.removeItem('id');
       setShowDeleteModal(false);
       navigate('/list', { replace: true });
@@ -171,7 +179,7 @@ export default function AnswerPage() {
     }
   };
 
-  // 답변 삭제(선택적으로 유지)
+  // 답변 삭제, answer-> null로 저장
   const onDeleteAnswer = async answerId => {
     try {
       await deleteAnswer(answerId);
@@ -185,11 +193,14 @@ export default function AnswerPage() {
     }
   };
 
-  // ✅ 질문 삭제: DELETE /questions/{questionId}/
+  // api 엔드포인트에 질문삭제 요청보내고 질문리스트에서 카드 없애버리기, 질문이 지워지면 질문개수 -1
   const onDeleteQuestion = async questionId => {
     try {
       await deleteQuestionApi(questionId);
       setQuestionList(prev => prev.filter(item => item.id !== questionId));
+      setLiveTotal(prev =>
+        typeof prev === 'number' ? Math.max(0, prev - 1) : prev
+      );
     } catch (e) {
       throw new Error(apiError(e));
     }
@@ -209,8 +220,9 @@ export default function AnswerPage() {
     };
   });
 
-  // 총 질문 개수: 리스트 totalCount → 프로필 questionCount → 로컬 렌더 개수
+  // 총 질문 개수 우선순위  1. 리스트 totalCount  2. 프로필 questionCount 3. 로컬 렌더 개수
   const totalQuestions =
+    (typeof liveTotal === 'number' ? liveTotal : null) ??
     (typeof totalCount === 'number' ? totalCount : null) ??
     (typeof userInfo?.questionCount === 'number'
       ? userInfo.questionCount
@@ -301,8 +313,8 @@ export default function AnswerPage() {
                     dislike={c.dislike}
                     onCreate={onCreateAnswer}
                     onEdit={onEditAnswer}
-                    onDelete={onDeleteAnswer} // (선택) 답변 삭제 유지
-                    onDeleteQuestion={onDeleteQuestion} // ✅ 질문 삭제 콜백 전달
+                    onDelete={onDeleteAnswer} //답변 삭제
+                    onDeleteQuestion={onDeleteQuestion} //질문 삭제
                   />
                 ))}
 


### PR DESCRIPTION
## 📌 PR 제목

케밥버튼 수정

## 📝 작업 내용

오전 토의결과 질문 삭제에 대한 기능 필요성이 느껴저 찬민님이 급하게 추가해주셨습니다.

## 🔍 주요 변경 사항

기존에는 본인 피드에서 질문에서 답변을 한 후 케밥버튼을 누르면 수정하기, 답변삭제 총 2개가 나왔지만

변경 이후

질문에 답변을 하지않으면 케밥 버튼 클릭시 질문삭제 버튼 1개만 나오게되고

답변을 하게되면 케밥버튼 클릭시 수정하기, 답변삭제, 질문삭제 총 3개의 버튼이 나오게 됩니다.

각자 배포 완료 및 머지 후에 확인해보시면 좋을 것 같아요.

## 💬 기타 참고 사항

기능 추가를 기준으로 발표자료 다시 준비해보겠습니다.

찬민님 기능 구현 빠르게 해주셔서 감사합니다 (__)
